### PR TITLE
Add text.html.rails as additional default selector

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -36,5 +36,5 @@ class ERBLint(Linter):
     tempfile_suffix = 'erb'
     error_stream = util.STREAM_STDOUT
     defaults = {
-        'selector': 'text.html.ruby'
+        'selector': 'text.html.ruby, text.html.rails'
     }


### PR DESCRIPTION
Default selector doesn't properly identify source files of `HTML (Rails)`. These are of type `text.html.rails`. I've tested this with a local configuration and it displays linting properly for .erb files